### PR TITLE
Support to ModelTiePointTag and ModelPixelScaleTag and external ExifTool executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,19 @@ foreach ($Reader as $MetaDatas) {
 ### Exiftool Writer
 
 ```php
+<?php
+
+require __DIR__ . '/vendor/autoload.php';
+
+use Monolog\Logger;
 use PHPExiftool\Writer;
-use PHPExiftool\Driver\Metadata;
-use PHPExiftool\Driver\MetadataBag;
+use PHPExiftool\Driver\Metadata\Metadata;
+use PHPExiftool\Driver\Metadata\MetadataBag;
 use PHPExiftool\Driver\Tag\IPTC\ObjectName;
 use PHPExiftool\Driver\Value\Mono;
 
-$Writer = Writer::create();
+$logger = new Logger('exiftool');
+$Writer = Writer::create($logger);
 
 $bag = new MetadataBag();
 $bag->add(new Metadata(new ObjectName(), new Mono('Pretty cool subject')));

--- a/lib/PHPExiftool/Driver/Tag/IFD0/ExtraSamples.php
+++ b/lib/PHPExiftool/Driver/Tag/IFD0/ExtraSamples.php
@@ -1,0 +1,61 @@
+<?php 
+
+/*
+ * This file is part of PHPExifTool.
+ *
+ * (c) 2012 Romain Neutron <imprec@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPExiftool\Driver\Tag\IFD0;
+
+use JMS\Serializer\Annotation\ExclusionPolicy;
+use PHPExiftool\Driver\AbstractTag;
+
+/**
+ * @ExclusionPolicy("all")
+ */
+class ExtraSamples extends AbstractTag
+{
+
+    protected $Id = 338;
+
+    protected $Name = 'ExtraSamples';
+
+    protected $FullName = 'Exif::Main';
+
+    protected $GroupName = 'IFD0';
+
+    protected $g0 = 'EXIF';
+
+    protected $g1 = 'IFD0';
+
+    protected $g2 = 'Image';
+
+    protected $Type = '?';
+
+    protected $Writable = false;
+
+    protected $Description = 'Extra Samples';
+
+    protected $local_g1 = 'ExifIFD';
+
+    protected $Values = array(
+        0 => array(
+            'Id' => 0,
+            'Label' => 'Unspecified',
+        ),
+        1 => array(
+            'Id' => 1,
+            'Label' => 'Associated Alpha',
+        ),
+        2 => array(
+            'Id' => 2,
+            'Label' => 'Unassociated Alpha',
+        ),
+    );
+
+}
+

--- a/lib/PHPExiftool/Driver/Tag/IFD0/ModelTiePoint.php
+++ b/lib/PHPExiftool/Driver/Tag/IFD0/ModelTiePoint.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of PHPExifTool.
+ *
+ * (c) 2012 Romain Neutron <imprec@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPExiftool\Driver\Tag\IFD0;
+
+use PHPExiftool\Driver\AbstractTag;
+
+class ModelTiePoint extends AbstractTag
+{
+
+    protected $Id = 33922;
+
+    protected $Name = 'ModelTiePoint';
+
+    protected $FullName = 'ModelTiepointTag';
+
+    protected $GroupName = 'IFD0';
+
+    protected $g0 = 'EXIF';
+
+    protected $g1 = 'IFD0';
+
+    protected $g2 = 'Image';
+
+    protected $Type = 'Double';
+
+    protected $Writable = false;
+
+    protected $Description = 'This tag stores raster->model tiepoint pairs';
+
+}

--- a/lib/PHPExiftool/Driver/Tag/IFD0/PixelScale.php
+++ b/lib/PHPExiftool/Driver/Tag/IFD0/PixelScale.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of PHPExifTool.
+ *
+ * (c) 2012 Romain Neutron <imprec@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPExiftool\Driver\Tag\IFD0;
+
+use PHPExiftool\Driver\AbstractTag;
+
+class PixelScale extends AbstractTag
+{
+
+    protected $Id = 33550;
+
+    protected $Name = 'PixelScale';
+
+    protected $FullName = 'ModelPixelScaleTag';
+
+    protected $GroupName = 'IFD0';
+
+    protected $g0 = 'EXIF';
+
+    protected $g1 = 'IFD0';
+
+    protected $g2 = 'Image';
+
+    protected $Type = 'Double';
+
+    protected $Writable = false;
+
+    protected $Description = 'This tag may be used to specify the size of raster pixel spacing in the model space units, when the raster space can be embedded in the model space coordinate system without rotation';
+
+}

--- a/lib/PHPExiftool/Exiftool.php
+++ b/lib/PHPExiftool/Exiftool.php
@@ -19,10 +19,12 @@ use Symfony\Component\Process\Process;
 class Exiftool implements LoggerAwareInterface
 {
     private $logger;
+    private $binaryPath;
 
-    public function __construct(LoggerInterface $logger)
+    public function __construct(LoggerInterface $logger, $binaryPath = null)
     {
         $this->logger = $logger;
+        $this->binaryPath = $binaryPath;
     }
 
     /**
@@ -44,7 +46,7 @@ class Exiftool implements LoggerAwareInterface
      */
     public function executeCommand($command)
     {
-        $command = self::getBinary() . ' ' . $command;
+        $command = ($this->binaryPath == null? self::getBinary(): $this->binaryPath) . ' ' . $command;
         $process = new Process($command);
 
         $this->logger->addInfo(sprintf('Exiftool executes command %s', $process->getCommandLine()));


### PR DESCRIPTION
With these two classes (ModelTiePoint and PixelScale) and the information retrieved with the other tags, you can calculate the extent of a GeoTIFF.

With the changes to the ExifTool class, you can specify an external ExifTool executable (useful if you already have an ExifTool installation in the system and you want to use that).
