### PR TITLE
Allow version 3 of symfony components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
         "doctrine/collections": "^1.0",
         "monolog/monolog": "^1.3",
         "phpexiftool/exiftool": "10.10",
-        "symfony/console": "^2.1",
-        "symfony/process": "^2.1"
+        "symfony/console": "^2.1|^3.0",
+        "symfony/process": "^2.1|^3.0"
     },
     "suggest": {
         "jms/serializer": "To serialize tags",

--- a/lib/PHPExiftool/Tool/Command/ClassesBuilder.php
+++ b/lib/PHPExiftool/Tool/Command/ClassesBuilder.php
@@ -19,6 +19,7 @@ use PHPExiftool\ClassUtils\TagProviderBuilder;
 use PHPExiftool\Exiftool;
 use PHPExiftool\InformationDumper;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -342,7 +343,6 @@ class ClassesBuilder extends Command
 
     protected function extractDump($dump, OutputInterface $output)
     {
-        $progress = $this->getHelper('progress');
 
         $crawler = new Crawler();
         $crawler->addContent($dump);
@@ -354,7 +354,13 @@ class ClassesBuilder extends Command
             $output->writeln(sprintf('%d', $tag_count));
         }
 
-        $progress->start($output, $tag_count);
+        if (!$this->getHelperSet()->has('progress')) {
+            $progress = new ProgressBar($output);
+            $progress->start($tag_count);
+        } else {
+            $progress = $this->getHelper('progress');
+            $progress->start($output, $tag_count);
+        }
 
         foreach ($crawler->filter('table') as $table) {
             $table_crawler = new Crawler();


### PR DESCRIPTION
Allow versions 3.x.y of symfony components.

composer update; vendor/bin/phpunit => all green
composer update --prefer-lowest; vendor/bin/phpunit => all green
