### PR TITLE
add Symfony 7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,14 +35,14 @@
         "doctrine/cache": "^1.0",
         "doctrine/collections": "^1.0",
         "exiftool/exiftool": "*",
-        "symfony/console": "^5 || ^6.2",
-        "symfony/css-selector": "^5 || ^6.2",
-        "symfony/dom-crawler": "^5 || ^6.2",
-        "symfony/process": "^5 || ^6",
+        "symfony/console": "^5 || ^6.2 || ^7.0",
+        "symfony/css-selector": "^5 || ^6.2 || ^7.0",
+        "symfony/dom-crawler": "^5 || ^6.2 || ^7.0",
+        "symfony/process": "^5 || ^6 || ^7.0",
         "ext-dom": "*",
         "cache/array-adapter": "^1.2",
         "ext-json": "*",
-        "symfony/monolog-bridge": "^5.4 || ^6.2"
+        "symfony/monolog-bridge": "^5.4 || ^6.2 || ^7.0"
     },
     "suggest": {
         "jms/serializer": "To serialize tags",
@@ -52,7 +52,7 @@
         "jms/serializer": "~3",
         "phpunit/phpunit": "^9.6.7",
         "symfony/finder": "^5",
-        "symfony/yaml": "^5 || ^6"
+        "symfony/yaml": "^5 || ^6 || ^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
     ],
     "require": {
         "php": "^7.4 || ^8.2",
-        "doctrine/cache": "^1.0",
         "doctrine/collections": "^1.0",
         "exiftool/exiftool": "*",
         "symfony/console": "^5 || ^6.2 || ^7.0",
@@ -40,9 +39,9 @@
         "symfony/dom-crawler": "^5 || ^6.2 || ^7.0",
         "symfony/process": "^5 || ^6 || ^7.0",
         "ext-dom": "*",
-        "cache/array-adapter": "^1.2",
         "ext-json": "*",
-        "symfony/monolog-bridge": "^5.4 || ^6.2 || ^7.0"
+        "symfony/monolog-bridge": "^5.4 || ^6.2 || ^7.0",
+        "symfony/cache": "^5 || ^6.2 || ^7.0"
     },
     "suggest": {
         "jms/serializer": "To serialize tags",

--- a/lib/PHPExiftool/FileEntity.php
+++ b/lib/PHPExiftool/FileEntity.php
@@ -12,7 +12,6 @@
 namespace PHPExiftool;
 
 
-use Cache\Adapter\PHPArray\ArrayCachePool;
 use DOMDocument;
 use Exception;
 use IteratorAggregate;
@@ -20,6 +19,7 @@ use PHPExiftool\Driver\Metadata\MetadataBag;
 use PHPExiftool\Driver\Value\ValueInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Cache\InvalidArgumentException;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 
 /**
@@ -51,7 +51,7 @@ class FileEntity implements IteratorAggregate
         // $this->dom = $dom;
         $this->file = $file;
 
-        $this->cache = new ArrayCachePool();
+        $this->cache = new ArrayAdapter();
 
         $this->parser = $parser->open($dom->saveXML());
 


### PR DESCRIPTION
This PR adds Symfony 7 support. Symfony 7 was released in November 2023.

I ran the test suite and got one failure, but it’s unrelated to this particular change. I will open an other PR to address it though.
