### PR TITLE
fix and update test suite

### DIFF
--- a/lib/PHPExiftool/FileEntity.php
+++ b/lib/PHPExiftool/FileEntity.php
@@ -62,7 +62,7 @@ class FileEntity implements IteratorAggregate
      * @throws InvalidArgumentException
      * @throws Exception
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return $this->getMetadatas()->getIterator();
     }

--- a/lib/PHPExiftool/InformationDumper.php
+++ b/lib/PHPExiftool/InformationDumper.php
@@ -83,7 +83,7 @@ class InformationDumper
      * @return DOMDocument
      * @throws Exception
      */
-    public function listDatas(string $type = self::LISTTYPE_SUPPORTED_XML, array $options = [], array $lngs): DOMDocument
+    public function listDatas(string $type = self::LISTTYPE_SUPPORTED_XML, array $options = [], array $lngs = []): DOMDocument
     {
         if (!is_array($options)) {
             throw new InvalidArgumentException('options must be an array');

--- a/tests/lib/PHPExiftool/PHPExiftoolTest.php
+++ b/tests/lib/PHPExiftool/PHPExiftoolTest.php
@@ -12,20 +12,14 @@ namespace lib\PHPExiftool;
 
 use PHPExiftool\Exception\DirectoryNotFoundException;
 use PHPExiftool\PHPExiftool;
-use PHPExiftool\Reader;
 use PHPUnit\Framework\TestCase;
 
-
-class PHPExiftoolTest extends TestCase {
-
-    private ?PHPExiftool $PHPExiftool = null;
-    protected static string $tmpDir = "";
-    protected static bool $disableSymLinkTest = false;
-
+class PHPExiftoolTest extends TestCase
+{
     /**
      * @covers PHPExiftool::__construct
      */
-    public function testRelativeClassesRootDirectory()
+    public function testRelativeClassesRootDirectory(): void
     {
         $this->expectException(DirectoryNotFoundException::class);
         new PHPExiftool("./relative_dir");
@@ -34,7 +28,7 @@ class PHPExiftoolTest extends TestCase {
     /**
      * @covers PHPExiftool::__construct
      */
-    public function testBadClassesRootDirectory()
+    public function testBadClassesRootDirectory(): void
     {
         $this->expectException(DirectoryNotFoundException::class);
         new PHPExiftool("/non_existing_dir");

--- a/tests/lib/PHPExiftool/RDFParserTest.php
+++ b/tests/lib/PHPExiftool/RDFParserTest.php
@@ -10,14 +10,15 @@
 
 namespace lib\PHPExiftool;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
+use PHPExiftool\Driver\Value\Binary;
+use PHPExiftool\Driver\Value\Mono;
+use PHPExiftool\Driver\Value\Multi;
+use PHPExiftool\FileEntity;
 use PHPExiftool\RDFParser;
-use PHPExiftool\Exception\LogicException;
-use PHPExiftool\Exception\ParseErrorException;
-use PHPExiftool\Exception\RuntimeException;
 use PHPUnit\Framework\TestCase;
-
 
 class RDFParserTest extends TestCase
 {
@@ -35,7 +36,7 @@ class RDFParserTest extends TestCase
     /**
      * @covers RDFParser::open
      */
-    public function testOpen()
+    public function testOpen(): void
     {
         $this->object->open(file_get_contents(__DIR__ . '/../../files/simplefile.xml'));
     }
@@ -43,7 +44,7 @@ class RDFParserTest extends TestCase
     /**
      * @covers RDFParser::close
      */
-    public function testClose()
+    public function testClose(): void
     {
         $this->object->close();
     }
@@ -54,15 +55,15 @@ class RDFParserTest extends TestCase
      * @covers RDFParser::getDomXpath
      * @covers RDFParser::getNamespacesFromXml
      */
-    public function testParseEntities()
+    public function testParseEntities(): void
     {
         $entities = $this->object
             ->open(file_get_contents(__DIR__ . '/../../files/simplefile.xml'))
             ->parseEntities();
 
-        $this->assertInstanceOf('\\Doctrine\\Common\\Collections\\ArrayCollection', $entities);
-        $this->assertEquals(1, count($entities));
-        $this->assertInstanceOf('\\PHPExiftool\\FileEntity', $entities->first());
+        $this->assertInstanceOf(ArrayCollection::class, $entities);
+        $this->assertCount(1, $entities);
+        $this->assertInstanceOf(FileEntity::class, $entities->first());
     }
 
     /**
@@ -71,7 +72,7 @@ class RDFParserTest extends TestCase
      * @covers RDFParser::getDomXpath
      * @covers \PHPExiftool\Exception\LogicException
      */
-    public function testParseEntitiesWithoutDom()
+    public function testParseEntitiesWithoutDom(): void
     {
         $this->expectException(\LogicException::class);
         $this->object->parseEntities();
@@ -84,7 +85,7 @@ class RDFParserTest extends TestCase
      * @covers \PHPExiftool\Exception\ParseErrorException
      * @covers \PHPExiftool\Exception\RuntimeException
      */
-    public function testParseEntitiesWrongDom()
+    public function testParseEntitiesWrongDom(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->object->open('wrong xml')->parseEntities();
@@ -95,21 +96,21 @@ class RDFParserTest extends TestCase
      * @covers RDFParser::getDom
      * @covers RDFParser::getDomXpath
      */
-    public function testParseMetadatas()
+    public function testParseMetadatas(): void
     {
         $metadatas = $this->object
             ->open(file_get_contents(__DIR__ . '/../../files/ExifTool.xml'))
             ->ParseMetadatas();
 
         $this->assertInstanceOf('\\PHPExiftool\\Driver\\Metadata\\MetadataBag', $metadatas);
-        $this->assertEquals(348, count($metadatas));
+        $this->assertCount(348, $metadatas);
     }
 
     /**
      * @covers RDFParser::Query
      * @covers RDFParser::readNodeValue
      */
-    public function testQuery()
+    public function testQuery(): void
     {
         $xml = "<?xml version='1.0' encoding='UTF-8'?>
             <rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
@@ -136,9 +137,9 @@ class RDFParserTest extends TestCase
         $this->assertNull($null_datas);
         $this->assertNull($null_datas_2);
 
-        $this->assertInstanceOf('\\PHPExiftool\\Driver\\Value\\Mono', $metadata_simple);
-        $this->assertInstanceOf('\\PHPExiftool\\Driver\\Value\\Binary', $metadata_base64);
-        $this->assertInstanceOf('\\PHPExiftool\\Driver\\Value\\Multi', $metadata_multi);
+        $this->assertInstanceOf(Mono::class, $metadata_simple);
+        $this->assertInstanceOf(Binary::class, $metadata_base64);
+        $this->assertInstanceOf(Multi::class, $metadata_multi);
 
         $this->assertEquals('Hello World !', $metadata_simple->asString());
         $this->assertEquals('Hello base64 !', $metadata_base64->asString());

--- a/tests/lib/PHPExiftool/ReaderTest.php
+++ b/tests/lib/PHPExiftool/ReaderTest.php
@@ -10,18 +10,19 @@
 
 namespace lib\PHPExiftool;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Iterator;
 use PHPExiftool\Exception\EmptyCollectionException;
 use PHPExiftool\Exception\LogicException;
 use PHPExiftool\Exception\RuntimeException;
+use PHPExiftool\FileEntity;
 use PHPExiftool\PHPExiftool;
 use PHPExiftool\Reader;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Process;
 
-
-
-class ReaderTest extends TestCase {
-
+class ReaderTest extends TestCase
+{
     private ?PHPExiftool $PHPExiftool = null;
     protected static string $tmpDir = "";
     protected static bool $disableSymLinkTest = false;
@@ -127,36 +128,36 @@ class ReaderTest extends TestCase {
     /**
      * @covers Reader::getIterator
      */
-    public function testGetIterator()
+    public function testGetIterator(): void
     {
         $file = self::$tmpDir . '/test.jpg';
         $reader = $this->createReader();
-        $this->assertInstanceOf('\\Iterator', $reader->files($file)->getIterator());
+        $this->assertInstanceOf(Iterator::class, $reader->files($file)->getIterator());
     }
 
     /**
      * @covers Reader::append
      * @covers Reader::all
      */
-    public function testAppend()
+    public function testAppend(): void
     {
         $reader1 = $this->createReader();
         $file1 = self::$tmpDir . '/test.jpg';
         $file2 = self::$tmpDir . '/test2.jpg';
         $file3 = self::$tmpDir . '/dir/CanonRaw.cr2';
-        $this->assertEquals(1, count($reader1->files($file1)->all()));
+        $this->assertCount(1, $reader1->files($file1)->all());
 
 
         $reader2 = $this->createReader();
         $reader2->files(array($file2, $file3));
-        $this->assertEquals(3, count($reader2->append($reader1)->all()));
+        $this->assertCount(3, $reader2->append($reader1)->all());
     }
 
     /**
      * @covers Reader::sort
      * @covers Reader::all
      */
-    public function testSort()
+    public function testSort(): void
     {
         $file1 = self::$tmpDir . '/test.jpg';
         $file2 = self::$tmpDir . '/test2.jpg';
@@ -180,7 +181,7 @@ class ReaderTest extends TestCase {
      * @covers Reader::buildQuery
      * @throws EmptyCollectionException
      */
-    public function testFiles()
+    public function testFiles(): void
     {
         $reader = $this->createReader();
 
@@ -195,7 +196,7 @@ class ReaderTest extends TestCase {
     /**
      * @covers Reader::resetResults
      */
-    public function testResetFilters()
+    public function testResetFilters(): void
     {
         $reader = $this->createReader();
 
@@ -204,34 +205,34 @@ class ReaderTest extends TestCase {
         $file = self::$tmpDir . '/test2.jpg';
         $reader->files($file)->all();
 
-        $this->assertEquals(2, count($reader->all()));
+        $this->assertCount(2, $reader->all());
     }
 
     /**
      * @covers Reader::ignoreDotFiles
      * @covers Reader::all
      */
-    public function testIgnoreVCS()
+    public function testIgnoreVCS(): void
     {
         $reader = $this->createReader();
 
         $reader->in(self::$tmpDir . '3');
-        $this->assertEquals(1, count($reader->all()));
+        $this->assertCount(1, $reader->all());
     }
 
     /**
      * @covers Reader::ignoreDotFiles
      * @covers Reader::all
      */
-    public function testIgnoreDotFiles()
+    public function testIgnoreDotFiles(): void
     {
         $reader = $this->createReader();
 
         $reader->in(self::$tmpDir . '3');
-        $this->assertEquals(1, count($reader->all()));
+        $this->assertCount(1, $reader->all());
 
         $reader->ignoreDotFiles()->in(self::$tmpDir . '3');
-        $this->assertEquals(0, count($reader->all()));
+        $this->assertCount(0, $reader->all());
     }
 
     /**
@@ -239,15 +240,15 @@ class ReaderTest extends TestCase {
      * @covers Reader::buildQuery
      * @covers Reader::all
      */
-    public function testIn()
+    public function testIn(): void
     {
         $reader = $this->createReader();
 
         $reader->reset()->in(self::$tmpDir);
-        $this->assertEquals(3, count($reader->all()));
+        $this->assertCount(3, $reader->all());
 
         $reader->reset()->in(self::$tmpDir . '/dir');
-        $this->assertEquals(1, count($reader->all()));
+        $this->assertCount(1, $reader->all());
 
         $reader->reset()->in(__DIR__ . '/../../../vendor/exiftool/exiftool/');
 
@@ -263,7 +264,7 @@ class ReaderTest extends TestCase {
      * @covers Reader::buildQuery
      * @covers Reader::all
      */
-    public function testExclude()
+    public function testExclude(): void
     {
         $reader = $this->createReader();
 
@@ -271,7 +272,7 @@ class ReaderTest extends TestCase {
                 ->in(self::$tmpDir)
                 ->exclude(self::$tmpDir . '/dir');
 
-        $this->assertEquals(2, count($reader->all()));
+        $this->assertCount(2, $reader->all());
     }
 
     /**
@@ -279,7 +280,7 @@ class ReaderTest extends TestCase {
      * @covers Reader::computeExcludeDirs
      * @covers Reader::all
      */
-    public function testComputeExcludeDirs($dir)
+    public function testComputeExcludeDirs(string $dir): void
     {
         $reader = $this->createReader();
 
@@ -289,6 +290,9 @@ class ReaderTest extends TestCase {
                 ->all();
     }
 
+    /**
+     * @return array<string>
+     */
     public function getExclude(): array
     {
         return array(
@@ -307,7 +311,7 @@ class ReaderTest extends TestCase {
      * @covers Reader::computeExcludeDirs
      * @covers \PHPExiftool\Exception\RuntimeException
      */
-    public function testComputeExcludeDirsFail($dir)
+    public function testComputeExcludeDirsFail(string $dir): void
     {
         $reader = $this->createReader();
 
@@ -318,6 +322,9 @@ class ReaderTest extends TestCase {
                 ->all();
     }
 
+    /**
+     * @return array<string>
+     */
     public function getWrongExclude(): array
     {
         return array(
@@ -335,42 +342,42 @@ class ReaderTest extends TestCase {
      * @covers Reader::buildQuery
      * @covers Reader::buildQueryAndExecute
      */
-    public function testExtensions()
+    public function testExtensions(): void
     {
         $reader = $this->createReader();
         $reader->in(self::$tmpDir);
-        $this->assertEquals(3, count($reader->all()));
+        $this->assertCount(3, $reader->all());
 
         $reader = $this->createReader();
         $reader->in(self::$tmpDir)->notRecursive()->extensions(array('cr2'));
-        $this->assertEquals(0, count($reader->all()));
+        $this->assertCount(0, $reader->all());
 
         $reader = $this->createReader();
         $reader->in(self::$tmpDir)->extensions(array('cr2'));
-        $this->assertEquals(1, count($reader->all()));
+        $this->assertCount(1, $reader->all());
 
         $reader = $this->createReader();
         $reader->in(self::$tmpDir)->extensions(array('jpg'));
-        $this->assertEquals(2, count($reader->all()));
+        $this->assertCount(2, $reader->all());
 
         $reader = $this->createReader();
         $reader->in(self::$tmpDir)->extensions('jpg')->extensions('cr2');
-        $this->assertEquals(3, count($reader->all()));
+        $this->assertCount(3, $reader->all());
 
         $reader = $this->createReader();
         $reader->in(self::$tmpDir)->extensions(array('jpg'), false);
-        $this->assertEquals(1, count($reader->all()));
+        $this->assertCount(1, $reader->all());
 
         $reader = $this->createReader();
         $reader->in(self::$tmpDir)->extensions(array('cr2', 'jpg'), false)->notRecursive();
-        $this->assertEquals(0, count($reader->all()));
+        $this->assertCount(0, $reader->all());
     }
 
     /**
      * @covers Reader::extensions
      * @covers \PHPExiftool\Exception\LogicException
      */
-    public function testExtensionsMisUse()
+    public function testExtensionsMisUse(): void
     {
         $reader = $this->createReader();
 
@@ -381,7 +388,7 @@ class ReaderTest extends TestCase {
     /**
      * @covers Reader::followSymLinks
      */
-    public function testFollowSymLinks()
+    public function testFollowSymLinks(): void
     {
         if (self::$disableSymLinkTest) {
             $this->markTestSkipped('This system does not support symlinks');
@@ -392,26 +399,26 @@ class ReaderTest extends TestCase {
         $reader->in(self::$tmpDir)
                 ->followSymLinks();
 
-        $this->assertInstanceOf('\\Doctrine\\Common\\Collections\\ArrayCollection', $reader->all());
-        $this->assertEquals(4, count($reader->all()));
+        $this->assertInstanceOf(ArrayCollection::class, $reader->all());
+        $this->assertCount(4, $reader->all());
     }
 
     /**
      * @covers Reader::notRecursive
      * @covers Reader::buildQuery
      */
-    public function testNotRecursive()
+    public function testNotRecursive(): void
     {
         $reader = $this->createReader();
 
         $reader->in(self::$tmpDir)->notRecursive();
-        $this->assertEquals(2, count($reader->all()));
+        $this->assertCount(2, $reader->all());
     }
 
     /**
      * @covers Reader::getOneOrNull
      */
-    public function testGetOneOrNull()
+    public function testGetOneOrNull(): void
     {
         $reader = $this->createReader();
 
@@ -424,7 +431,7 @@ class ReaderTest extends TestCase {
      * @covers Reader::first
      * @covers \PHPExiftool\Exception\EmptyCollectionException
      */
-    public function testFirstEmpty()
+    public function testFirstEmpty(): void
     {
         $reader = $this->createReader();
 
@@ -436,19 +443,19 @@ class ReaderTest extends TestCase {
     /**
      * @covers Reader::first
      */
-    public function testFirst()
+    public function testFirst(): void
     {
         $reader = $this->createReader();
 
         $reader->in(self::$tmpDir);
 
-        $this->assertInstanceOf('\\PHPExiftool\\FileEntity', $reader->first());
+        $this->assertInstanceOf(FileEntity::class, $reader->first());
     }
 
     /**
      * @covers Reader::buildQuery
      */
-    public function testFail()
+    public function testFail(): void
     {
         $reader = $this->createReader();
 
@@ -460,14 +467,14 @@ class ReaderTest extends TestCase {
      * @covers Reader::all
      * @covers Reader::buildQueryAndExecute
      */
-    public function testAll()
+    public function testAll(): void
     {
         $reader = $this->createReader();
 
         $reader->in(self::$tmpDir);
 
-        $this->assertInstanceOf('\\Doctrine\\Common\\Collections\\ArrayCollection', $reader->all());
-        $this->assertEquals(3, count($reader->all()));
+        $this->assertInstanceOf(ArrayCollection::class, $reader->all());
+        $this->assertCount(3, $reader->all());
     }
 
 }

--- a/tests/lib/PHPExiftool/Test/AbstractPreviewExtractorTest.php
+++ b/tests/lib/PHPExiftool/Test/AbstractPreviewExtractorTest.php
@@ -10,17 +10,18 @@
 
 namespace lib\PHPExiftool\Test;
 
-use lib\PHPExiftool\PreviewExtractor;
+use DirectoryIterator;
+use PHPExiftool\PreviewExtractor;
 use PHPExiftool\Exception\LogicException;
+use PHPExiftool\Exiftool;
 use PHPUnit\Framework\TestCase;
 
 abstract class AbstractPreviewExtractorTest extends TestCase
 {
-
     /**
-     * @covers PHPExiftool\PreviewExtractor::extract
+     * @covers \PHPExiftool\PreviewExtractor::extract
      */
-    public function testExtract()
+    public function testExtract(): void
     {
         $extractor = new PreviewExtractor($this->getExiftool());
 
@@ -30,7 +31,7 @@ abstract class AbstractPreviewExtractorTest extends TestCase
 
         $files = $extractor->extract(__DIR__ . '/../../../files/ExifTool.jpg', $tmpDir);
 
-        $this->assertInstanceOf('\\DirectoryIterator', $files);
+        $this->assertInstanceOf(DirectoryIterator::class, $files);
 
         $n = 0;
         $unlinks = array();
@@ -51,7 +52,7 @@ abstract class AbstractPreviewExtractorTest extends TestCase
         $this->assertEquals(1, $n);
     }
 
-    public function testExtractWrongFile()
+    public function testExtractWrongFile(): void
     {
         $extractor = new PreviewExtractor($this->getExiftool());
 
@@ -61,7 +62,7 @@ abstract class AbstractPreviewExtractorTest extends TestCase
         $extractor->extract(__DIR__ . '/ExifTool.jpg', $tmpDir);
     }
 
-    public function testExtractWrongDir()
+    public function testExtractWrongDir(): void
     {
         $extractor = new PreviewExtractor($this->getExiftool());
 
@@ -71,5 +72,5 @@ abstract class AbstractPreviewExtractorTest extends TestCase
         $extractor->extract(__DIR__ . '/../../../files/ExifTool.jpg', $tmpDir);
     }
 
-    abstract protected function getExiftool();
+    abstract protected function getExiftool(): Exiftool;
 }

--- a/tests/lib/PHPExiftool/Test/Command/PreviewExtractor.php
+++ b/tests/lib/PHPExiftool/Test/Command/PreviewExtractor.php
@@ -10,17 +10,14 @@
 
 namespace lib\PHPExiftool\Test\Command;
 
-require_once __DIR__ . '/../AbstractPreviewExtractorTest.php';
-
+use lib\PHPExiftool\Test\AbstractPreviewExtractorTest;
 use Monolog\Logger;
 use Monolog\Handler\NullHandler;
-use lib\PHPExiftool\AbstractPreviewExtractorTest;
-use lib\PHPExiftool\Exiftool;
+use PHPExiftool\Exiftool;
 
 class PreviewExtractor extends AbstractPreviewExtractorTest
 {
-
-    protected function getExiftool()
+    protected function getExiftool(): Exiftool
     {
         $logger = new Logger('Tests');
         $logger->pushHandler(new NullHandler());

--- a/tests/lib/PHPExiftool/Test/Driver/Metadata/MetadataBagTest.php
+++ b/tests/lib/PHPExiftool/Test/Driver/Metadata/MetadataBagTest.php
@@ -15,10 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class MetadataBagTest extends TestCase
 {
-    /**
-     * @var MetadataBag
-     */
-    protected $object;
+    protected MetadataBag $object;
 
     protected function setUp(): void
     {
@@ -28,12 +25,12 @@ class MetadataBagTest extends TestCase
     /**
      * @covers MetadataBag::filterKeysByRegExp
      */
-    public function testFilterKeysByRegExp()
+    public function testFilterKeysByRegExp(): void
     {
         $this->object->set('oneKey', 'oneValue');
         $this->object->set('oneSecondKey', 'anotherValue');
         $this->object->set('thirdKey', 'thirdValue');
 
-        $this->assertEquals(2, count($this->object->filterKeysByRegExp('/one.*/')));
+        $this->assertCount(2, $this->object->filterKeysByRegExp('/one.*/'));
     }
 }

--- a/tests/lib/PHPExiftool/Test/Driver/Metadata/MetadataTest.php
+++ b/tests/lib/PHPExiftool/Test/Driver/Metadata/MetadataTest.php
@@ -13,16 +13,14 @@ namespace lib\PHPExiftool\Test\Driver\Metadata;
 use PHPExiftool\Driver\AbstractTagGroup;
 use PHPExiftool\Driver\Value\Mono;
 use PHPExiftool\Driver\Metadata\Metadata;
+use PHPExiftool\Driver\Value\ValueInterface;
 use PHPUnit\Framework\TestCase;
 
 class MetadataTest extends TestCase
 {
-    /**
-     * @var Metadata
-     */
-    protected $object;
-    protected $tag;
-    protected $value;
+    protected Metadata $object;
+    protected TagTest $tag;
+    protected ValueInterface $value;
 
     /**
      * @covers Metadata::__construct
@@ -37,7 +35,7 @@ class MetadataTest extends TestCase
     /**
      * @covers Metadata::getTagGroup
      */
-    public function testGetTag()
+    public function testGetTag(): void
     {
         $this->assertEquals($this->object->getTagGroup(), $this->tag);
     }
@@ -45,7 +43,7 @@ class MetadataTest extends TestCase
     /**
      * @covers Metadata::getValue
      */
-    public function testGetValue()
+    public function testGetValue(): void
     {
         $this->assertEquals($this->object->getValue(), $this->value);
     }

--- a/tests/lib/PHPExiftool/Test/Driver/TagGroupFactoryTest.php
+++ b/tests/lib/PHPExiftool/Test/Driver/TagGroupFactoryTest.php
@@ -31,14 +31,12 @@ class TagGroupFactoryTest extends TestCase
         return $this->PHPExiftool->getFactory()->createTagGroup($tagName);
     }
 
-
-
     /**
      * @covers TagGroupFactory::GetFromRDFTagname
      * @covers TagGroupFactory::classnameFromTagname
      * @throws TagUnknown
      */
-    public function testGetFromRDFTagname()
+    public function testGetFromRDFTagname(): void
     {
         $tag = TagGroupFactory::getFromRDFTagname("/tmp", 'IPTC:SupplementalCategories');
         $this->assertInstanceOf(get_class($this->createTagGroup("IPTC:SupplementalCategories")), $tag);
@@ -46,13 +44,8 @@ class TagGroupFactoryTest extends TestCase
         $tag = TagGroupFactory::getFromRDFTagname("/tmp", 'XMP_exif:ApertureValue');
         $this->assertInstanceOf(get_class($this->createTagGroup("XMP_exif:ApertureValue")), $tag);
 
-        try {
-            TagGroupFactory::getFromRDFTagname("/tmp", 'XMP_exif:NonExistingTag');
-            $this->fail('Should raise a TagUnknown exception');
-        }
-        catch (TagUnknown $e) {
-
-        }
+        $this->expectException(TagUnknown::class);
+        TagGroupFactory::getFromRDFTagname("/tmp", 'XMP_exif:NonExistingTag');
     }
 
     /**
@@ -61,7 +54,7 @@ class TagGroupFactoryTest extends TestCase
      *
      * @throws TagUnknown
      */
-    public function testGetFromRDFTagnameFail()
+    public function testGetFromRDFTagnameFail(): void
     {
         $this->expectException(TagUnknown::class);
         TagGroupFactory::getFromRDFTagname("/tmp", 'XMP_exif:NonExistingTag');
@@ -70,7 +63,7 @@ class TagGroupFactoryTest extends TestCase
     /**
      * @covers TagGroupFactory::HasFromRDFTagname
      */
-    public function testHasFromRDFTagname()
+    public function testHasFromRDFTagname(): void
     {
         $this->assertTrue(TagGroupFactory::hasFromRDFTagname("/tmp", 'IPTC:SupplementalCategories'));
         $this->assertFalse(TagGroupFactory::hasFromRDFTagname("/tmp", 'XMP_exif:NonExistingTag'));

--- a/tests/lib/PHPExiftool/Test/Driver/TagGroupTest.php
+++ b/tests/lib/PHPExiftool/Test/Driver/TagGroupTest.php
@@ -17,9 +17,8 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Finder\Finder;
 use PHPExiftool\Driver\TagGroupInterface;
 
-
-class TagGroupTest extends TestCase {
-
+class TagGroupTest extends TestCase
+{
     /**
      * @var TagGroupInterface
      */
@@ -36,7 +35,7 @@ class TagGroupTest extends TestCase {
      * @covers AbstractTag::isWritable
      * @covers AbstractTag::isBinary
      */
-    public function testConsistency()
+    public function testConsistency(): void
     {
         $PHPExiftool = new PHPExiftool("/tmp");
 

--- a/tests/lib/PHPExiftool/Test/Driver/Value/BinaryTest.php
+++ b/tests/lib/PHPExiftool/Test/Driver/Value/BinaryTest.php
@@ -17,10 +17,7 @@ use PHPUnit\Framework\TestCase;
 
 class BinaryTest extends TestCase
 {
-    /**
-     * @var Binary
-     */
-    protected $object;
+    protected Binary $object;
 
     /**
      * @covers Binary::__construct
@@ -33,7 +30,7 @@ class BinaryTest extends TestCase
     /**
      * @covers Binary::getType
      */
-    public function testGetType()
+    public function testGetType(): void
     {
         $this->assertEquals(ValueInterface::TYPE_BINARY, $this->object->getType());
     }
@@ -41,7 +38,7 @@ class BinaryTest extends TestCase
     /**
      * @covers Binary::asString
      */
-    public function testAsString()
+    public function testAsString(): void
     {
         $this->assertEquals('Binary', $this->object->asString());
     }
@@ -49,7 +46,7 @@ class BinaryTest extends TestCase
     /**
      * @covers Binary::asBase64
      */
-    public function testAsBase64()
+    public function testAsBase64(): void
     {
         $this->assertEquals(base64_encode('Binary'), $this->object->asBase64());
     }
@@ -57,7 +54,7 @@ class BinaryTest extends TestCase
     /**
      * @covers Binary::set
      */
-    public function testSetValue()
+    public function testSetValue(): void
     {
         $this->object->set('Daisy');
         $this->assertEquals('Daisy', $this->object->asString());
@@ -66,7 +63,7 @@ class BinaryTest extends TestCase
     /**
      * @covers Binary::setBase64Value
      */
-    public function testSetBase64Value()
+    public function testSetBase64Value(): void
     {
         $this->object->setBase64Value('UmlyaSBGaWZpIGV0IExvdWxvdQ==');
         $this->assertEquals('Riri Fifi et Loulou', $this->object->asString());
@@ -76,7 +73,7 @@ class BinaryTest extends TestCase
      * @covers Binary::setBase64Value
      * @covers InvalidArgumentException
      */
-    public function testSetWrongBase64Value()
+    public function testSetWrongBase64Value(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->object->setBase64Value('Riri Fifi et Loulou !');
@@ -85,7 +82,7 @@ class BinaryTest extends TestCase
     /**
      * @covers Binary::loadFromBase64
      */
-    public function testLoadFromBase64()
+    public function testLoadFromBase64(): void
     {
         $object = Binary::loadFromBase64('VW5jbGUgU2Nyb29nZQ==');
         $this->assertEquals('Uncle Scrooge', $object->asString());
@@ -96,7 +93,7 @@ class BinaryTest extends TestCase
      * @covers Binary::loadFromBase64
      * @covers InvalidArgumentException
      */
-    public function testLoadFromWrongBase64()
+    public function testLoadFromWrongBase64(): void
     {
         $this->expectException(InvalidArgumentException::class);
         Binary::loadFromBase64('Uncle Scrooge !!!');

--- a/tests/lib/PHPExiftool/Test/Driver/Value/MonoTest.php
+++ b/tests/lib/PHPExiftool/Test/Driver/Value/MonoTest.php
@@ -16,10 +16,7 @@ use PHPUnit\Framework\TestCase;
 
 class MonoTest extends TestCase
 {
-    /**
-     * @var Mono
-     */
-    protected $object;
+    protected Mono $object;
 
     /**
      * @covers Mono::__construct
@@ -32,7 +29,7 @@ class MonoTest extends TestCase
     /**
      * @covers Mono::getType
      */
-    public function testGetType()
+    public function testGetType(): void
     {
         $this->assertEquals(ValueInterface::TYPE_MONO, $this->object->getType());
     }
@@ -40,7 +37,7 @@ class MonoTest extends TestCase
     /**
      * @covers Mono::asString
      */
-    public function testAsString()
+    public function testAsString(): void
     {
         $this->assertEquals('Hello !', $this->object->asString());
     }
@@ -48,7 +45,7 @@ class MonoTest extends TestCase
     /**
      * @covers Mono::set
      */
-    public function testSetValue()
+    public function testSetValue(): void
     {
         $this->object->set('World !');
         $this->assertEquals('World !', $this->object->asString());

--- a/tests/lib/PHPExiftool/Test/Driver/Value/MultiTest.php
+++ b/tests/lib/PHPExiftool/Test/Driver/Value/MultiTest.php
@@ -16,10 +16,7 @@ use PHPUnit\Framework\TestCase;
 
 class MultiTest extends TestCase
 {
-    /**
-     * @var Multi
-     */
-    protected $object;
+    protected Multi $object;
 
     /**
      * @covers Multi::__construct
@@ -32,7 +29,7 @@ class MultiTest extends TestCase
     /**
      * @covers Multi::getType
      */
-    public function testGetType()
+    public function testGetType(): void
     {
         $this->assertEquals(ValueInterface::TYPE_MULTI, $this->object->getType());
     }
@@ -40,7 +37,7 @@ class MultiTest extends TestCase
     /**
      * @covers Multi::asArray
      */
-    public function testAsArray()
+    public function testAsArray(): void
     {
         $this->assertEquals(array('hello', 'world !'), $this->object->asArray());
     }
@@ -48,7 +45,7 @@ class MultiTest extends TestCase
     /**
      * @covers Multi::addValue
      */
-    public function testAddValue()
+    public function testAddValue(): void
     {
         $this->object->addValue('tim');
         $this->assertEquals(array('hello', 'world !', 'tim'), $this->object->asArray());
@@ -57,7 +54,7 @@ class MultiTest extends TestCase
     /**
      * @covers Multi::reset
      */
-    public function testReset()
+    public function testReset(): void
     {
         $this->object->reset();
         $this->assertEquals(array(), $this->object->asArray());

--- a/tests/lib/PHPExiftool/Test/ExiftoolTest.php
+++ b/tests/lib/PHPExiftool/Test/ExiftoolTest.php
@@ -15,25 +15,23 @@ use Monolog\Logger;
 use Monolog\Handler\NullHandler;
 use PHPExiftool\Exception\RuntimeException;
 use PHPExiftool\Exiftool;
-use lib\PHPExiftool;
 use PHPUnit\Framework\TestCase;
 
 class ExiftoolTest extends TestCase
 {
-
     /**
-     * @covers PHPExiftool\Exiftool::executeCommand
+     * @covers \PHPExiftool\Exiftool::executeCommand
      * @throws Exception
      */
     public function testExecuteCommand()
     {
         $exiftool = new Exiftool($this->getlogger());
-        $this->assertRegExp('/\d+\.\d+/', $exiftool->executeCommand(['-ver']));
+        $this->assertMatchesRegularExpression('/\d+\.\d+/', $exiftool->executeCommand(['-ver']));
     }
 
     /**
-     * @covers PHPExiftool\Exiftool::executeCommand
-     * @covers PHPExiftool\Exception\RuntimeException
+     * @covers \PHPExiftool\Exiftool::executeCommand
+     * @covers \PHPExiftool\Exception\RuntimeException
      * @throws Exception
      */
     public function testExecuteCommandFailed()

--- a/tests/lib/PHPExiftool/Test/FileEntityTest.php
+++ b/tests/lib/PHPExiftool/Test/FileEntityTest.php
@@ -10,8 +10,13 @@
 
 namespace lib\PHPExiftool\Test;
 
+use Iterator;
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
+use PHPExiftool\Driver\Metadata\MetadataBag;
+use PHPExiftool\Driver\Value\Binary;
+use PHPExiftool\Driver\Value\Mono;
+use PHPExiftool\Driver\Value\Multi;
 use PHPExiftool\FileEntity;
 use PHPExiftool\RDFParser;
 use PHPUnit\Framework\TestCase;
@@ -38,15 +43,15 @@ class FileEntityTest extends TestCase
     /**
      * @covers FileEntity::getIterator
      */
-    public function testGetIterator()
+    public function testGetIterator(): void
     {
-        $this->assertInstanceOf('\\Iterator', $this->object->getIterator());
+        $this->assertInstanceOf(Iterator::class, $this->object->getIterator());
     }
 
     /**
      * @covers FileEntity::getFile
      */
-    public function testGetFile()
+    public function testGetFile(): void
     {
         $this->assertIsString($this->object->getFile());
     }
@@ -54,27 +59,27 @@ class FileEntityTest extends TestCase
     /**
      * @covers FileEntity::getMetadatas
      */
-    public function testGetMetadatas()
+    public function testGetMetadatas(): void
     {
-        $this->assertInstanceOf('\\PHPExiftool\Driver\Metadata\MetadataBag', $this->object->getMetadatas());
+        $this->assertInstanceOf(MetadataBag::class, $this->object->getMetadatas());
         $this->assertCount(348, $this->object->getMetadatas());
     }
 
     /**
      * @covers FileEntity::executeQuery
      */
-    public function testExecuteQuery()
+    public function testExecuteQuery(): void
     {
-        $this->assertInstanceOf('\\PHPExiftool\\Driver\\Value\\Mono', $this->object->executeQuery('IFD0:Copyright'));
+        $this->assertInstanceOf(Mono::class, $this->object->executeQuery('IFD0:Copyright'));
         $this->assertEquals('Copyright 2004 Phil Harvey', $this->object->executeQuery('IFD0:Copyright')->asString());
 
-        $this->assertInstanceOf('\\PHPExiftool\\Driver\\Value\\Binary', $this->object->executeQuery('CIFF:FreeBytes'));
+        $this->assertInstanceOf(Binary::class, $this->object->executeQuery('CIFF:FreeBytes'));
 
-        $this->assertInstanceOf('\\PHPExiftool\\Driver\\Value\\Multi', $this->object->executeQuery('XMP-dc:Subject'));
+        $this->assertInstanceOf(Multi::class, $this->object->executeQuery('XMP-dc:Subject'));
         $this->assertEquals(array('ExifTool', 'Test', 'XMP'), $this->object->executeQuery('XMP-dc:Subject')->asArray());
     }
 
-    public function testCacheKey()
+    public function testCacheKey(): void
     {
         $o = new FileEntity('bad_{}()/\\@:_chars', new \DOMDocument(), new RDFParser("/tmp", $this->logger));
         $k = $o->getCacheKey();

--- a/tests/lib/PHPExiftool/Test/InformationDumperTest.php
+++ b/tests/lib/PHPExiftool/Test/InformationDumperTest.php
@@ -20,10 +20,7 @@ use PHPUnit\Framework\TestCase;
 
 class InformationDumperTest extends TestCase
 {
-    /**
-     * @var InformationDumper
-     */
-    protected $object;
+    protected InformationDumper $object;
 
     protected function setUp(): void
     {
@@ -36,7 +33,7 @@ class InformationDumperTest extends TestCase
     /**
      * @covers InformationDumper::listDatas
      */
-    public function testListDatas()
+    public function testListDatas(): void
     {
         $this->object->listDatas();
     }
@@ -45,7 +42,7 @@ class InformationDumperTest extends TestCase
      * @covers InformationDumper::listDatas
      * @covers InvalidArgumentException
      */
-    public function testListDatasInvalidType()
+    public function testListDatasInvalidType(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->object->listDatas('Scrooge');
@@ -55,7 +52,7 @@ class InformationDumperTest extends TestCase
      * @covers InformationDumper::listDatas
      * @covers DirectoryNotFoundException
      */
-    public function testBadDirectory()
+    public function testBadDirectory(): void
     {
         $this->markTestIncomplete(
             'DirectoryNotFoundException cannot be forced because directory is created.'

--- a/tests/lib/PHPExiftool/WriterTest.php
+++ b/tests/lib/PHPExiftool/WriterTest.php
@@ -11,6 +11,8 @@
 namespace lib\PHPExiftool;
 
 use PHPExiftool\Driver;
+use PHPExiftool\Driver\Metadata\Metadata;
+use PHPExiftool\Driver\Metadata\MetadataBag;
 use PHPExiftool\Driver\TagGroupInterface;
 use PHPExiftool\Exception\InvalidArgumentException;
 use PHPExiftool\PHPExiftool;
@@ -18,32 +20,6 @@ use PHPExiftool\Writer;
 use PHPExiftool\Reader;
 use PHPExiftool\Exception\EmptyCollectionException;
 use PHPUnit\Framework\TestCase;
-
-class WriterTester extends Writer
-{
-    private Writer $writer;
-
-    public function __construct(Writer $writer)
-    {
-        parent::__construct($writer->exiftool);
-        $this->writer = $writer;
-    }
-
-    public function __call($name, $args)
-    {
-        return call_user_func($this->writer->{$name}, $args);
-    }
-
-    public function addMetadatasArgTester($metadatas): array
-    {
-        return $this->writer->addMetadatasArg($metadatas);
-    }
-
-    public function getSyncCommandTester(): array
-    {
-        return $this->writer->getSyncCommand();
-    }
-}
 
 class WriterTest extends TestCase
 {
@@ -90,13 +66,11 @@ class WriterTest extends TestCase
         return $this->PHPExiftool->getFactory()->createTagGroup($tagName);
     }
 
-
-
     /**
      * @covers Writer::setMode
      * @covers Writer::isMode
      */
-    public function testSetMode()
+    public function testSetMode(): void
     {
         $writer = $this->createWriter();
 
@@ -114,11 +88,11 @@ class WriterTest extends TestCase
      * @covers Writer::copy
      * @throws EmptyCollectionException
      */
-    public function testCopy()
+    public function testCopy(): void
     {
         $writer = $this->createWriter();
 
-        $metadatas = new Driver\Metadata\MetadataBag();
+        $metadatas = new MetadataBag();
         $writer->erase(true, true);
         $changedFiles = $writer->write($this->inWithICC, $metadatas, $this->out);
         $this->assertEquals(1, $changedFiles);
@@ -138,7 +112,7 @@ class WriterTest extends TestCase
      * @covers Writer::setModule
      * @covers Writer::hasModule
      */
-    public function testSetModule()
+    public function testSetModule(): void
     {
         $writer = $this->createWriter();
 
@@ -154,16 +128,16 @@ class WriterTest extends TestCase
      * @covers Writer::erase
      * @throws EmptyCollectionException
      */
-    public function testEraseWithoutICC()
+    public function testEraseWithoutICC(): void
     {
         $writer = $this->createWriter();
         $reader = $this->createReader();
 
         $uniqueId = 'UNI-QUE-ID';
 
-        $metadatas = new Driver\Metadata\MetadataBag();
-        $metadatas->add(new Driver\Metadata\Metadata($this->createTagGroup("IPTC:UniqueDocumentID"), new Driver\Value\Mono($uniqueId)));
-        $metadatas->add(new Driver\Metadata\Metadata($this->createTagGroup("XMP_exif:ImageUniqueID"), new Driver\Value\Mono($uniqueId)));
+        $metadatas = new MetadataBag();
+        $metadatas->add(new Metadata($this->createTagGroup("IPTC:UniqueDocumentID"), new Driver\Value\Mono($uniqueId)));
+        $metadatas->add(new Metadata($this->createTagGroup("XMP_exif:ImageUniqueID"), new Driver\Value\Mono($uniqueId)));
 
         $writer->erase(true, false);
         $changedFiles = $writer->write($this->inWithICC, $metadatas, $this->out);
@@ -213,16 +187,16 @@ class WriterTest extends TestCase
     /**
      * @throws EmptyCollectionException
      */
-    public function testEraseWithICC()
+    public function testEraseWithICC(): void
     {
         $writer = $this->createWriter();
         $reader = $this->createReader();
 
         $uniqueId = 'UNI-QUE-ID';
 
-        $metadatas = new Driver\Metadata\MetadataBag();
-        $metadatas->add(new Driver\Metadata\Metadata($this->createTagGroup("IPTC:UniqueDocumentID"), new Driver\Value\Mono($uniqueId)));
-        $metadatas->add(new Driver\Metadata\Metadata($this->createTagGroup("XMP_exif:ImageUniqueID"), new Driver\Value\Mono($uniqueId)));
+        $metadatas = new MetadataBag();
+        $metadatas->add(new Metadata($this->createTagGroup("IPTC:UniqueDocumentID"), new Driver\Value\Mono($uniqueId)));
+        $metadatas->add(new Metadata($this->createTagGroup("XMP_exif:ImageUniqueID"), new Driver\Value\Mono($uniqueId)));
 
         $writer->erase(true, true);
         $changedFiles = $writer->write($this->inWithICC, $metadatas, $this->out);
@@ -273,15 +247,15 @@ class WriterTest extends TestCase
      * @covers Writer::write
      * @throws EmptyCollectionException
      */
-    public function testWrite()
+    public function testWrite(): void
     {
         $writer = $this->createWriter();
         $reader = $this->createReader();
 
-        $metadatas = new Driver\Metadata\MetadataBag();
-        $metadatas->add(new Driver\Metadata\Metadata($this->createTagGroup("IPTC:ObjectName"), new Driver\Value\Mono('Beautiful Object')));
-        $metadatas->add(new Driver\Metadata\Metadata($this->createTagGroup("IPTC:ObjectName"), new Driver\Value\Mono('Beautiful Object')));
-        $metadatas->add(new Driver\Metadata\Metadata($this->createTagGroup("XMP_iptcExt:PersonInImage"), new Driver\Value\Multi(['Romain', 'Nicolas'])));
+        $metadatas = new MetadataBag();
+        $metadatas->add(new Metadata($this->createTagGroup("IPTC:ObjectName"), new Driver\Value\Mono('Beautiful Object')));
+        $metadatas->add(new Metadata($this->createTagGroup("IPTC:ObjectName"), new Driver\Value\Mono('Beautiful Object')));
+        $metadatas->add(new Metadata($this->createTagGroup("XMP_iptcExt:PersonInImage"), new Driver\Value\Multi(['Romain', 'Nicolas'])));
 
         $changedFiles = $writer->write($this->in, $metadatas, $this->out);
 
@@ -299,15 +273,15 @@ class WriterTest extends TestCase
      * @covers Writer::write
      * @throws EmptyCollectionException
      */
-    public function testWriteInPlace()
+    public function testWriteInPlace(): void
     {
         $writer = $this->createWriter();
         $reader = $this->createReader();
 
-        $metadatas = new Driver\Metadata\MetadataBag();
-        $metadatas->add(new Driver\Metadata\Metadata($this->createTagGroup("IPTC:ObjectName"), new Driver\Value\Mono('Beautiful Object')));
-        $metadatas->add(new Driver\Metadata\Metadata($this->createTagGroup("IPTC:ObjectName"), new Driver\Value\Mono('Beautiful Object')));
-        $metadatas->add(new Driver\Metadata\Metadata($this->createTagGroup("XMP_iptcExt:PersonInImage"), new Driver\Value\Multi(['Romain', 'Nicolas'])));
+        $metadatas = new MetadataBag();
+        $metadatas->add(new Metadata($this->createTagGroup("IPTC:ObjectName"), new Driver\Value\Mono('Beautiful Object')));
+        $metadatas->add(new Metadata($this->createTagGroup("IPTC:ObjectName"), new Driver\Value\Mono('Beautiful Object')));
+        $metadatas->add(new Metadata($this->createTagGroup("XMP_iptcExt:PersonInImage"), new Driver\Value\Multi(['Romain', 'Nicolas'])));
 
         $changedFiles = $writer->write($this->inPlace, $metadatas);
 
@@ -325,15 +299,15 @@ class WriterTest extends TestCase
      * @covers Writer::write
      * @throws EmptyCollectionException
      */
-    public function testWriteInPlaceErased()
+    public function testWriteInPlaceErased(): void
     {
         $writer = $this->createWriter();
         $reader = $this->createReader();
 
-        $metadatas = new Driver\Metadata\MetadataBag();
-        $metadatas->add(new Driver\Metadata\Metadata($this->createTagGroup("IPTC:ObjectName"), new Driver\Value\Mono('Beautiful Object')));
-        $metadatas->add(new Driver\Metadata\Metadata($this->createTagGroup("IPTC:ObjectName"), new Driver\Value\Mono('Beautiful Object')));
-        $metadatas->add(new Driver\Metadata\Metadata($this->createTagGroup("XMP_iptcExt:PersonInImage"), new Driver\Value\Multi(['Romain', 'Nicolas'])));
+        $metadatas = new MetadataBag();
+        $metadatas->add(new Metadata($this->createTagGroup("IPTC:ObjectName"), new Driver\Value\Mono('Beautiful Object')));
+        $metadatas->add(new Metadata($this->createTagGroup("IPTC:ObjectName"), new Driver\Value\Mono('Beautiful Object')));
+        $metadatas->add(new Metadata($this->createTagGroup("XMP_iptcExt:PersonInImage"), new Driver\Value\Multi(['Romain', 'Nicolas'])));
 
         $writer->erase(true);
         $changedFiles = $writer->write($this->inPlace, $metadatas);
@@ -352,18 +326,18 @@ class WriterTest extends TestCase
      * @covers Writer::write
      * @covers InvalidArgumentException
      */
-    public function testWriteFail()
+    public function testWriteFail(): void
     {
         $writer = $this->createWriter();
 
         $this->expectException(InvalidArgumentException::class);
-        $writer->write('ici', new Driver\Metadata\MetadataBag());
+        $writer->write('ici', new MetadataBag());
     }
 
     /**
      * @covers Writer::addMetadatasArg
      */
-    public function testAddMetadatasArg()
+    public function testAddMetadatasArg(): void
     {
         $this->markTestIncomplete();
 
@@ -413,7 +387,7 @@ class WriterTest extends TestCase
         */
     }
 
-    private function _testContains($a, $modes)
+    private function _testContains($a, $modes): void
     {
         foreach ($modes as $mode) {
             $this->assertContains($mode[1], $a);


### PR DESCRIPTION
This PR fixes a failing tests, removes all deprecation and warning from the test suite. It also makes the code more consistent by adding return types to every methods.

Other improvements made are:
- Using `assertCount(x, y)` instead of `assertEquals(x, count(y))` for clarity.
- Using `MyClass::class` rather than `\\Namespace\\MyClass` when asserting the instance of a class.
- Removing dead code.
- Improving the general code style for more consistency.
- Changing the `assertRegExp` to `assertMatchesRegularExpression` as the former is deprecated is PHPUnit 10+.
- Remove the `require` statement in favor of proper namespace imports.

I would also be happy to add a GitHub workflow to replace the travis pipeline if this is something you’d like to do.